### PR TITLE
Message link auto-replacement functionality.

### DIFF
--- a/cogs/message_link.py
+++ b/cogs/message_link.py
@@ -61,16 +61,36 @@ class JumpView(discord.ui.View):
 
 
 class MessageLink(commands.Cog):
-
-    def __init__(self, bot):
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    @commands.command(name="link")
-    async def message_link(self, ctx: commands.Context, message: discord.Message):
+    @commands.Cog.listener('on_message')
+    async def link_message(self, message: discord.Message):
         """Command for embedding a linked message."""
-        jump_view = JumpView(message)
-        await ctx.send(embed=jump_view.create_embed(ctx.author), view=jump_view)
-        await ctx.message.delete()
+        if message.author == self.bot.user:
+            return
+        # Checking if the message sent is a link to a discord message.
+        link_regex = re.compile(
+            r'https?://(?:(ptb|canary|www)\.)?discord(?:app)?\.com/channels/'
+            r'(?P<guild_id>[0-9]{15,20}|@me)'
+            r'/(?P<channel_id>[0-9]{15,20})/(?P<message_id>[0-9]{15,20})/?$'
+        )
+        match = link_regex.match(message.content)
+        # If it's not a message link, we simply return.
+        if not match:
+            return
+        # Parsing out the channel ID and message ID from the regular expression.
+        data = match.groupdict()
+        channel_id = discord.utils._get_as_snowflake(data, 'channel_id')
+        message_id = int(data['message_id'])
+        linked_channel = self.bot.get_channel(channel_id)
+        partial_linked_message = linked_channel.get_partial_message(message_id)
+        # Fetching the full message.
+        linked_message = await partial_linked_message.fetch()
+        # Constructing the embed, and then deleting the original message.
+        jump_view = JumpView(linked_message)
+        await message.channel.send(embed=jump_view.create_embed(message.author), view=jump_view)
+        await message.delete()
 
 
 async def setup(bot: commands.Bot):

--- a/cogs/message_link.py
+++ b/cogs/message_link.py
@@ -70,12 +70,13 @@ class MessageLink(commands.Cog):
         if message.author == self.bot.user:
             return
         # Checking if the message sent is a link to a discord message.
+        id_regex = re.compile(r'(?:(?P<channel_id>[0-9]{15,20})-)?(?P<message_id>[0-9]{15,20})$')
         link_regex = re.compile(
             r'https?://(?:(ptb|canary|www)\.)?discord(?:app)?\.com/channels/'
             r'(?P<guild_id>[0-9]{15,20}|@me)'
             r'/(?P<channel_id>[0-9]{15,20})/(?P<message_id>[0-9]{15,20})/?$'
         )
-        match = link_regex.match(message.content)
+        match = link_regex.match(message.content) or id_regex.match(message.content)
         # If it's not a message link, we simply return.
         if not match:
             return
@@ -87,7 +88,7 @@ class MessageLink(commands.Cog):
         partial_linked_message = linked_channel.get_partial_message(message_id)
         # Fetching the full message.
         linked_message = await partial_linked_message.fetch()
-        # Constructing the embed, and then deleting the original message.
+        # Constructing the embed, and then deleting the original
         jump_view = JumpView(linked_message)
         await message.channel.send(embed=jump_view.create_embed(message.author), view=jump_view)
         await message.delete()

--- a/cogs/message_link.py
+++ b/cogs/message_link.py
@@ -54,6 +54,8 @@ class JumpView(discord.ui.View):
                 embed.add_field(
                     name="Attachment", value=f"[{file.filename}]({file.url})", inline=False)
         embed.add_field(name="Channel", value=msg.channel.mention)
+        embed.add_field(name="Posted",
+                        value=discord.utils.format_dt(msg.created_at, style='R'))
         # The footer is the person who linked the message.
         embed.set_footer(text=f"Linked by {author.display_name}",
                          icon_url=author.display_avatar.replace(format="png"))
@@ -70,13 +72,15 @@ class MessageLink(commands.Cog):
         if message.author == self.bot.user:
             return
         # Checking if the message sent is a link to a discord message.
-        id_regex = re.compile(r'(?:(?P<channel_id>[0-9]{15,20})-)?(?P<message_id>[0-9]{15,20})$')
+        id_regex = re.compile(
+            r'(?:(?P<channel_id>[0-9]{15,20})-)?(?P<message_id>[0-9]{15,20})$')
         link_regex = re.compile(
             r'https?://(?:(ptb|canary|www)\.)?discord(?:app)?\.com/channels/'
             r'(?P<guild_id>[0-9]{15,20}|@me)'
             r'/(?P<channel_id>[0-9]{15,20})/(?P<message_id>[0-9]{15,20})/?$'
         )
-        match = link_regex.match(message.content) or id_regex.match(message.content)
+        match = link_regex.match(
+            message.content) or id_regex.match(message.content)
         # If it's not a message link, we simply return.
         if not match:
             return

--- a/cogs/message_link.py
+++ b/cogs/message_link.py
@@ -86,8 +86,7 @@ class MessageLink(commands.Cog):
             return
         # Parsing out the channel ID and message ID from the regular expression.
         data = match.groupdict()
-        channel_id = discord.utils._get_as_snowflake(data, 'channel_id')
-        message_id = int(data['message_id'])
+        channel_id, message_id = int(data['channel_id']), int(data['message_id'])
         linked_channel = self.bot.get_channel(channel_id)
         partial_linked_message = linked_channel.get_partial_message(message_id)
         # Fetching the full message.
@@ -95,7 +94,9 @@ class MessageLink(commands.Cog):
         # Constructing the embed, and then deleting the original
         jump_view = JumpView(linked_message)
         await message.channel.send(embed=jump_view.create_embed(message.author), view=jump_view)
-        await message.delete()
+        # Only deleting if this is within a server, rather than a DM channel.
+        if message.guild:
+            await message.delete()
 
 
 async def setup(bot: commands.Bot):


### PR DESCRIPTION
Cog now replaces either links to messages or channel id/message id combo's with the embed, without the user invoking a command. The embed also now features a timestamp as to when the linked message was posted at.